### PR TITLE
Update Package.swift

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,11 @@
     "pins": [
       {
         "package": "RxExpect",
-        "repositoryURL": "https://github.com/devxoul/RxExpect.git",
+        "repositoryURL": "https://github.com/dmsl1805/RxExpect.git",
         "state": {
-          "branch": null,
-          "revision": "c3a3bb3d46ee831582c6619ecc48cda1cdbff890",
-          "version": "2.0.0"
+          "branch": "support-rxswift6",
+          "revision": "20719ff8d42bc6f9e17201ebf32a2d7dfbe7d12f",
+          "version": null
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/ReactiveX/RxSwift.git",
         "state": {
           "branch": null,
-          "revision": "002d325b0bdee94e7882e1114af5ff4fe1e96afa",
-          "version": "5.1.1"
+          "revision": "7e01c05f25c025143073eaa3be3532f9375c614b",
+          "version": "6.1.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "RxViewController",
   platforms: [
-    .macOS(.v10_11), .iOS(.v8), .tvOS(.v9)
+    .macOS(.v10_11), .iOS(.v9), .tvOS(.v9)
   ],
   products: [
     .library(name: "RxViewController", targets: ["RxViewController"]),

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,10 @@ let package = Package(
     .package(url: "https://github.com/dmsl1805/RxExpect.git", .branch("support-rxswift6")),
   ],
   targets: [
-    .target(name: "RxViewController", dependencies: ["RxSwift", "RxCocoa"]),
+    .target(name: "RxViewController", dependencies: [
+        .product(name: "RxSwift", package: "RxSwift"),
+        .product(name: "RxCocoa", package: "RxSwift")
+    ]),
     .testTarget(name: "RxViewControllerTests", dependencies: ["RxViewController", "RxExpect"]),
   ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/ReactiveX/RxSwift.git", .upToNextMajor(from: "6.0.0")),
-    .package(url: "https://github.com/devxoul/RxExpect.git", .upToNextMajor(from: "2.0.0")),
+    .package(url: "https://github.com/dmsl1805/RxExpect.git", .branch("support-rxswift6")),
   ],
   targets: [
     .target(name: "RxViewController", dependencies: ["RxSwift", "RxCocoa"]),


### PR DESCRIPTION
The package product 'RxSwift' requires minimum platform version 9.0 for the iOS platform, but this target supports 8.0
